### PR TITLE
Checks in place to fix possible PHP Warning

### DIFF
--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -247,7 +247,7 @@ function pmpropp_return_payment_plans( $level_id, $plan_id = '' ) {
 		 * @param bool $include_level_price Should the levels default pricing be automatically included at checkout.
 		 * @param int $level_id The level ID value of current checkout/level in question.
 		 */
-		if ( apply_filters( 'pmpropp_include_level_pricing_option_at_checkout', true, $level_id ) && ( is_page( $pmpro_pages['checkout'] ) || wp_doing_ajax() ) ) {
+		if ( apply_filters( 'pmpropp_include_level_pricing_option_at_checkout', true, $level_id ) && ( is_page( $pmpro_pages['checkout'] ) || wp_doing_ajax() ) && is_array( $payment_plans ) ) {
 			$level = pmpro_getLevel( $level_id );
 			$level->status = 'active';
 			$level->default = 'yes'; //Default to yes, as it can be adjusted by "real" plans later on.


### PR DESCRIPTION
Fixes a PHP warning that appears to show up when using free levels or changing to a level that doesn't have a payment plan on it