### PR TITLE
Fixes checkbox labels being clicked on edit page

### DIFF
--- a/includes/admin-payment-plan.php
+++ b/includes/admin-payment-plan.php
@@ -37,8 +37,8 @@
 					<label><?php esc_html_e( 'Recurring Subscription', 'pmpro-payment-plans' ); ?>:</label>
 				</th>
 				<td>
-					<input id="pmpropp_recurring" name="pmpropp_recurring[]" type="checkbox" value="yes"/> 
-					<label for="pmpropp_recurring"><?php esc_html_e( 'Check if this level has a recurring subscription payment.', 'pmpro-payment-plans' ); ?></label>
+					<input id="pmpropp_recurring_!!plan_id!!" name="pmpropp_recurring[]" class="pmpropp_recurring" type="checkbox" value="yes"/> 
+					<label for="pmpropp_recurring_!!plan_id!!"><?php esc_html_e( 'Check if this level has a recurring subscription payment.', 'pmpro-payment-plans' ); ?></label>
 				</td>
 			</tr>
 			<tr class="pmpropp_plan_recurring" style="display:none;">
@@ -112,7 +112,7 @@
 			<tr class="pmpropp_plan_recurring" style="display:none;">
 				<th scope="row" valign="top"><label><?php esc_html_e( 'Custom Trial', 'pmpro-payment-plans' ); ?>:</label></th>
 				<td>
-					<input id="pmpropp_custom_trial" name="pmpropp_custom_trial" type="checkbox" value="yes" onclick="jQuery('.pmpropp_trial_info').toggle();"/> <label for="pmpropp_custom_trial"><?php _e( 'Check to add a custom trial period.', 'pmpro-payment-plans' ); ?></label>
+					<input id="pmpropp_custom_trial_!!plan_id!!" class="pmpropp_custom_trial" name="pmpropp_custom_trial" type="checkbox" value="yes" onclick="jQuery('.pmpropp_trial_info').toggle();"/> <label for="pmpropp_custom_trial_!!plan_id!!"><?php _e( 'Check to add a custom trial period.', 'pmpro-payment-plans' ); ?></label>
 					<?php if ( $gateway == 'twocheckout' ) { ?>
 						<p class="description"><strong 
 						<?php
@@ -162,7 +162,7 @@
 			</tr>
 			<tr>
 				<th scope="row" valign="top"><label><?php esc_html_e( 'Membership Expiration', 'pmpro-payment-plans' ); ?>:</label></th>
-				<td><input id="pmpropp_plan_expiration" name="pmpropp_plan_expiration[]" type="checkbox" value="yes"> <label for="pmpropp_plan_expiration"><?php esc_html_e( 'Check this to set when membership access expires.', 'pmpro-payment-plans' ); ?></label></td>
+				<td><input id="pmpropp_plan_expiration_!!plan_id!!" class="pmpropp_plan_expiration" name="pmpropp_plan_expiration[]" type="checkbox" value="yes"> <label for="pmpropp_plan_expiration_!!plan_id!!"><?php esc_html_e( 'Check this to set when membership access expires.', 'pmpro-payment-plans' ); ?></label></td>
 			</tr>
 			<tr class="pmpropp_plan_expiration_info" style="display:none;">					
 				<th scope="row" valign="top"><label for="pmpropp_expiration_number"><?php esc_html_e( 'Expires In:', 'pmpro-payment-plans' ); ?></label></th>

--- a/js/admin.js
+++ b/js/admin.js
@@ -10,17 +10,17 @@ jQuery(document).ready(function () {
 
         // Show recurring settings by default.
         if (val.cycle_number) {
-            jQuery("#pmpropp_plan_" + key + " #pmpropp_recurring").prop('checked', true); //set it to checked.
+            jQuery("#pmpropp_plan_" + key + " .pmpropp_recurring").prop('checked', true); //set it to checked.
         }
 
         // Show trial by default.
         if (val.trial_limit) {
-            jQuery("#pmpropp_plan_" + key + " #pmpropp_custom_trial").prop('checked', true); //set it to checked.
+            jQuery("#pmpropp_plan_" + key + " .pmpropp_custom_trial").prop('checked', true); //set it to checked.
         }
 
         // Set the expiration checkbox to set if data is found.
         if (val.expiration_number) {
-            jQuery("#pmpropp_plan_" + key + " #pmpropp_plan_expiration").prop('checked', true); //set it to checked.
+            jQuery("#pmpropp_plan_" + key + " .pmpropp_plan_expiration").prop('checked', true); //set it to checked.
         }
 
     });
@@ -54,41 +54,44 @@ jQuery(document).ready(function () {
         var menu_order = jQuery(this).attr('menu_order');
         jQuery('#' + id + ' #pmpropp_display_order').val(menu_order);
 
-        jQuery('#' + id + ' #pmpropp_recurring').attr('menu_order', menu_order);
-        jQuery('#' + id + ' #pmpropp_plan_expiration').attr('menu_order', menu_order);
+        jQuery('#' + id + ' .pmpropp_recurring').attr('menu_order', menu_order);
+        jQuery('#' + id + ' .pmpropp_plan_expiration').attr('menu_order', menu_order);
 
         jQuery('#' + id + ' tr.pmpropp_plan_expiration_info').addClass('pmpropp_expirations_' + menu_order);
         jQuery('#' + id + ' tr.pmpropp_plan_recurring').addClass('pmpropp_recurring_' + menu_order);
         jQuery('#' + id + ' .pmpropp_trial_info').addClass('pmpropp_trial_info_' + menu_order);
 
         // Show the pmpropp_recurring_x field if the checkbox is pre-selected previously.
-        if (jQuery('#pmpropp_plan_' + menu_order + ' #pmpropp_recurring').prop('checked')) {
+        if (jQuery('#pmpropp_plan_' + menu_order + ' .pmpropp_recurring').prop('checked')) {
             jQuery('.pmpropp_plan_recurring.pmpropp_recurring_' + menu_order).show();
         }
 
         // Show the custom trial depending fields.
-        if (jQuery('#pmpropp_plan_' + menu_order + ' #pmpropp_custom_trial').prop('checked')) {
+        if (jQuery('#pmpropp_plan_' + menu_order + ' .pmpropp_custom_trial').prop('checked')) {
             jQuery('.pmpropp_trial_info_' + menu_order).show();
         }
 
-        if (jQuery('#pmpropp_plan_' + menu_order + ' #pmpropp_plan_expiration').prop('checked')) {
+        if (jQuery('#pmpropp_plan_' + menu_order + ' .pmpropp_plan_expiration').prop('checked')) {
             jQuery('.pmpropp_expirations_' + menu_order).show();
         }
     
         //Change the dropdown the selected cycle period        
-        var cycle_period_val = jQuery(".pmpropp_recurring_" + menu_order + " #cycle_period").attr("selectval");
-        jQuery(".pmpropp_recurring_" + menu_order + " #cycle_period").val(cycle_period_val).change();
+        var cycle_period_val = jQuery("#pmpropp_recurring_" + menu_order + " #cycle_period").attr("selectval");
+        jQuery("#pmpropp_recurring_" + menu_order + " #cycle_period").val(cycle_period_val).change();
 
         //Change the dropdown the selected expiration period        
         var expiration_period_val = jQuery(".pmpropp_expirations_" + menu_order + " #expiration_period").attr("selectval");
-        jQuery(".pmpropp_expirations_" + menu_order + " #expiration_period").val(expiration_period_val).change();
+        
+        if( expiration_period_val !== "" ){
+            jQuery(".pmpropp_expirations_" + menu_order + " #expiration_period").val(expiration_period_val).change();
+        }
 
     });
 
     /**
      * Show the items that depend on recurring billing checkbox.
      */
-    jQuery("body").on("click", "#pmpropp_recurring", function () {
+    jQuery("body").on("click", ".pmpropp_recurring", function () {
 
         var menu_order = jQuery(this).attr('menu_order');
 
@@ -100,8 +103,7 @@ jQuery(document).ready(function () {
 
     });
 
-    jQuery("body").on("click", "#pmpropp_plan_expiration", function () {
-        console.log('clicked');
+    jQuery("body").on("click", ".pmpropp_plan_expiration", function () {
 
         var menu_order = jQuery(this).attr('menu_order');
 

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -480,6 +480,8 @@ function pmpropp_render_plans( $template ) {
  */
 function pmpropp_replace_template_values( $template, $values ) {
 
+	$template = str_replace( '!!plan_id!!', ( ! empty( $values->id ) ) ? $values->id : '', $template );
+
 	$template = str_replace( '!!plan_name!!', ( ! empty( $values->name ) ) ? $values->name : '', $template );
 	$template = str_replace( '!!display_order!!', ( ! empty( $values->display_order ) ) ? $values->display_order : '', $template );
 	$template = str_replace( '!!billing_amount!!', ( ! empty( $values->billing_amount ) ) ? $values->billing_amount : '', $template );


### PR DESCRIPTION
Relates to #14

Checkboxes for expirations and recurring options work when the respective label is clicked on