### PR TITLE
Uninstall fixes

### DIFF
--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -37,4 +37,3 @@ function pmpropp_uninstall() {
        
     }
 }
-register_uninstall_hook( __FILE__, 'pmpropp_uninstall' );

--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -9,28 +9,32 @@ if ( !defined( 'ABSPATH' ) && !defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit();
 }
 
-if ( get_option( 'pmpro_uninstall', 0 ) ) {
+function pmpropp_uninstall() {
 
-    global $wpdb;
+    if ( get_option( 'pmpro_uninstall', 0 ) ) {
 
-    $tables = array(
-        'pmpro_membership_ordermeta',
-        'pmpro_membership_levelmeta',
-    );
+        global $wpdb;
 
-    foreach($tables as $table){
+        $tables = array(
+            'pmpro_membership_ordermeta',
+            'pmpro_membership_levelmeta',
+        );
 
-        $table_name = $wpdb->prefix . $table;
-        
-        // setup sql query
-        $sql = "DELETE FROM `$table_name` WHERE `meta_key` = 'payment_plan'";
-        
-        // run the query
-        $wpdb->query($sql);
+        foreach($tables as $table){
 
+            $table_name = $wpdb->prefix . $table;
+            
+            // setup sql query
+            $sql = "DELETE FROM `$table_name` WHERE `meta_key` = 'payment_plan'";
+            
+            // run the query
+            $wpdb->query($sql);
+
+        }
+
+        require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+        dbDelta( $sql );
+       
     }
-
-    require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
-    dbDelta( $sql );
-   
 }
+register_uninstall_hook( __FILE__, 'pmpropp_uninstall' );

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -12,6 +12,10 @@
  * Includes the cleanup script on uninstall.
  */
 include plugin_dir_path( __FILE__ ) . 'includes/uninstall.php';
+function pmpropp_activate(){
+    register_uninstall_hook( __FILE__, 'pmpropp_uninstall' );
+}
+register_activation_hook( __FILE__, 'pmpropp_activate' );
 
 /**
  * Load required scripts for admin settings.


### PR DESCRIPTION
- The uninstall script previously deleted all plan data whenever ANY plugin was uninstalled
- We now ensure that only if Payment Plans is uninstalled and the core option is set to delete that we remove the plan data