### PR TITLE
Enhance level check for loading scripts

### DIFF
--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -86,7 +86,13 @@ function pmpropp_load_frontend_scripts() {
 			$level = pmpro_getLevelAtCheckout();
 
 			// Get the level ID.
-			$level_id = ! empty( $level ) ? $level->id : ( ! empty( $_REQUEST['level'] ) ? $_REQUEST['level'] : false );
+			if ( ! empty( $level ) ) {
+				$level_id = intval( $level->id );
+			} elseif ( empty( $level ) && ! empty( $_REQUEST['level'] ) ) {
+				$level_id = intval( $_REQUEST['level'] );
+			} else {
+				$level_id = false;
+			}
 
 			// Do we have a level ID and payment plans for that level?
 			if ( empty( $level_id ) || empty( pmpropp_return_payment_plans( $level_id ) ) ) {

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -87,8 +87,6 @@ function pmpropp_load_frontend_scripts() {
 			// Get the level ID.
 			if ( ! empty( $level ) ) {
 				$level_id = intval( $level->id );
-			} elseif ( empty( $level ) && ! empty( $_REQUEST['level'] ) ) {
-				$level_id = intval( $_REQUEST['level'] );
 			} else {
 				$level_id = false;
 			}
@@ -104,7 +102,7 @@ function pmpropp_load_frontend_scripts() {
 				'pmpro-payment-plans-frontend-js',
 				'payment_plans',
 				array(
-					'plans'        => pmpropp_return_payment_plans( intval( $_REQUEST['level'] ) ),
+					'plans'        => pmpropp_return_payment_plans( $level_id ),
 					'ajaxurl'      => admin_url( 'admin-ajax.php' ),
 					'parent_level' => ( ! empty( $_REQUEST['level'] ) ? $_REQUEST['level'] : 0 ),
 				)

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -72,10 +72,26 @@ add_action( 'admin_enqueue_scripts', 'pmpropp_load_admin_scripts' );
  */
 function pmpropp_load_frontend_scripts() {
 
+	// Require PMPro
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
+		return;
+	}
+
 	global $pmpro_pages, $post;
 
 	if ( ! empty( $pmpro_pages['checkout'] ) && ! empty( $post->ID ) ) {
 		if ( $pmpro_pages['checkout'] == $post->ID ) {
+
+			// Get the level for checkout.
+			$level = pmpro_getLevelAtCheckout();
+
+			// Get the level ID.
+			$level_id = ! empty( $level ) ? $level->id : ( ! empty( $_REQUEST['level'] ) ? $_REQUEST['level'] : false );
+
+			// Do we have a level ID and payment plans for that level?
+			if ( empty( $level_id ) || empty( pmpropp_return_payment_plans( $level_id ) ) ) {
+				return;
+			}
 
 			wp_enqueue_script( 'pmpro-payment-plans-frontend-js', plugins_url( 'js/frontend.js', __FILE__ ) );
 

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -71,13 +71,12 @@ add_action( 'admin_enqueue_scripts', 'pmpropp_load_admin_scripts' );
  * @since 0.1
  */
 function pmpropp_load_frontend_scripts() {
+	global $pmpro_pages, $post;
 
 	// Require PMPro
 	if ( ! defined( 'PMPRO_VERSION' ) ) {
 		return;
 	}
-
-	global $pmpro_pages, $post;
 
 	if ( ! empty( $pmpro_pages['checkout'] ) && ! empty( $post->ID ) ) {
 		if ( $pmpro_pages['checkout'] == $post->ID ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Check that we have a level before loading scripts.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/pmpro-payment-plans/issues/37.

- Check the level for checkout using `pmpro_getLevelAtCheckout` first as this function already checks for the level parameter.
- Check if the level has payment plans.
- Only load scripts if the level has payment plans.

### How to test the changes in this Pull Request:

1. Enable WP DEBUG logging
2. Open the checkout page in a browser without a level parameter
3. Open debug log and confirm that no "Undefined index" error notification is logged
4. Check rendered page HTML to confirm that payment plans JS and CSS are not loaded (if the default level does not have payment plans) 
5. Open the checkout page in a browser with a level parameter for a level with payment plans
6. Check rendered page HTML to confirm that payment plans JS and CSS are loaded

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->