### PR TITLE
Resolves the issue of inactive plans not showing in admin

### DIFF
--- a/includes/admin-payment-plan.php
+++ b/includes/admin-payment-plan.php
@@ -1,5 +1,5 @@
 <div class="panel panel_template s_panel"> <!-- first panel -->
-	<h3 class="acc-header">!!plan_name!! <span class="pmpropp_small_text">(<?php esc_html_e( 'Click to view', 'pmpro-payment-plans' ); ?>)</span><span class="pmpropp_remove_plan"><?php esc_html_e( 'delete', 'pmpro-payment-plans' ); ?></span></h3>
+	<h3 class="acc-header">!!plan_name!! <span class="pmpropp_small_text">!!plan_status!! (<?php esc_html_e( 'Click to view', 'pmpro-payment-plans' ); ?>)</span><span class="pmpropp_remove_plan"><?php esc_html_e( 'delete', 'pmpro-payment-plans' ); ?></span></h3>
 	<div class="acc-body">		
 		<table class='form-table'>
 			<tr>

--- a/js/admin.js
+++ b/js/admin.js
@@ -39,7 +39,6 @@ jQuery(document).ready(function () {
         }
 
         var plan_status = jQuery("#pmpropp_plan_" + key + " #pmpropp_plan_status").attr("selectval");
-        console.log(plan_status);
         if (plan_status !== "") {
             jQuery("#pmpropp_plan_" + key + " #pmpropp_plan_status").val(plan_status).change();
         }

--- a/js/admin.js
+++ b/js/admin.js
@@ -38,6 +38,12 @@ jQuery(document).ready(function () {
             jQuery("#pmpropp_plan_" + key + " #expiration_period").val(expiration_period_val).change();
         }
 
+        var plan_status = jQuery("#pmpropp_plan_" + key + " #pmpropp_plan_status").attr("selectval");
+        console.log(plan_status);
+        if (plan_status !== "") {
+            jQuery("#pmpropp_plan_" + key + " #pmpropp_plan_status").val(plan_status).change();
+        }
+
     });
 
 

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -42,7 +42,7 @@ function pmpropp_load_admin_scripts() {
 		ob_end_clean();
 
 		$stored_plans = pmpropp_render_plans( $output, true );
-		$plan_data = pmpropp_return_payment_plans( intval( $_REQUEST['edit'] ), $is_admin );
+		$plan_data = pmpropp_return_payment_plans( intval( $_REQUEST['edit'] ), true );
 
 		$template_plan       = new StdClass();
 		$template_plan->name = __( 'New Payment Plan', 'pmpro-payment-plans' );

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -41,8 +41,8 @@ function pmpropp_load_admin_scripts() {
 		$output = ob_get_contents();
 		ob_end_clean();
 
-		$stored_plans = pmpropp_render_plans( $output );
-		$plan_data = pmpropp_return_payment_plans( intval( $_REQUEST['edit'] ) );
+		$stored_plans = pmpropp_render_plans( $output, true );
+		$plan_data = pmpropp_return_payment_plans( intval( $_REQUEST['edit'] ), $is_admin );
 
 		$template_plan       = new StdClass();
 		$template_plan->name = __( 'New Payment Plan', 'pmpro-payment-plans' );
@@ -266,7 +266,7 @@ function pmpropp_get_plan( $level_id, $plan_id ) {
  *
  * @return array $plan An array of the plans.
  */
-function pmpropp_return_payment_plans( $level_id ) {
+function pmpropp_return_payment_plans( $level_id, $is_admin = false ) {
 	global $pmpro_pages;
 
 	if ( empty( $level_id ) ) {
@@ -302,8 +302,10 @@ function pmpropp_return_payment_plans( $level_id ) {
 	}
 			
 	foreach ( $payment_plans as $plan ) {				
-
-		if ( $plan->status === 'active' ) {
+		/**
+		 * Show plans that are active, or if we're on the level edit page show all
+		 */
+		if ( $plan->status === 'active' || $is_admin ) {
 		
 			$ordered_plans[] = $plan;
 
@@ -517,13 +519,13 @@ add_action( 'wp_ajax_nopriv_pmpropp_request_price_change', 'pmpropp_request_pric
  *
  * @since 0.1
  */
-function pmpropp_render_plans( $template ) {
+function pmpropp_render_plans( $template, $is_admin = false ) {
 
 	$ret = '';
 
 	global $pmpro_currency_symbol;
 
-	$plans = pmpropp_return_payment_plans( intval( $_REQUEST['edit'] ) );
+	$plans = pmpropp_return_payment_plans( intval( $_REQUEST['edit'] ), $is_admin );
 
 	if ( ! empty( $plans ) ) {
 		foreach ( $plans as $plan ) {


### PR DESCRIPTION
Resolves #45

Steps to test: 

1. Edit your level and create multiple plans
2. Set one of the plans to Inactive
3. The plan should still show on the page (with inactive next to it) but not show on the front end.