### PR TITLE
Adds support for Add On Packages

### DIFF
--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -375,6 +375,17 @@ add_filter( 'pmpro_registration_checks', 'pmpropp_registration_checks', 10, 1);
  */
 function pmpropp_render_payment_plans_checkout() {
 
+	//Add in support for Add On Packages
+	if ( ! empty( $_REQUEST['ap'] ) && ! empty( $_REQUEST['level'] ) ) {
+		if ( pmpro_hasMembershipLevel( $_REQUEST['level'] ) ) {
+			/**
+			 * Purchasing an add on package and have the required level 
+			 * so don't show the payment plan options
+			 */
+			return;
+		}
+	}
+
 	if ( ! empty( $_REQUEST['level'] ) ) {
 
 		$plans = pmpropp_return_payment_plans( intval( $_REQUEST['level'] ) );


### PR DESCRIPTION
Resolves #42

Steps to test

1. Set up a level that makes use of payment plans
2. Create an Add On Package and require the level that has payment plans
3. Purchase a level with a payment plan
4. Attempt to purchase an add on package 'thing'
5. You should be able to purchase this without issues 