### PR TITLE
Changes the styling of a plan when inactive

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -36,3 +36,7 @@
 .pmpropp_small_text{
     font-size:10px;
 }
+
+.pmpro_payment_plan_level_container .inactive {
+    color: #AAA;
+}

--- a/includes/admin-payment-plan.php
+++ b/includes/admin-payment-plan.php
@@ -1,5 +1,5 @@
 <div class="panel panel_template s_panel"> <!-- first panel -->
-	<h3 class="acc-header">!!plan_name!! <span class="pmpropp_small_text">!!plan_status!! (<?php esc_html_e( 'Click to view', 'pmpro-payment-plans' ); ?>)</span><span class="pmpropp_remove_plan"><?php esc_html_e( 'delete', 'pmpro-payment-plans' ); ?></span></h3>
+	<h3 class="acc-header !!plan_status!!">!!plan_name!! <span class="pmpropp_small_text">!!plan_status!! (<?php esc_html_e( 'Click to view', 'pmpro-payment-plans' ); ?>)</span><span class="pmpropp_remove_plan"><?php esc_html_e( 'delete', 'pmpro-payment-plans' ); ?></span></h3>
 	<div class="acc-body">		
 		<table class='form-table'>
 			<tr>


### PR DESCRIPTION
Changes the styling of the plan when inactive

Steps to recreate: 

1. Create plans that are active, save them
2. Change the status of one of them to inactive and save
3. The inactive plans will be greyed out - same styling as the levels page makes use of for inactive levels

![image](https://user-images.githubusercontent.com/8989542/210352999-7743c8d9-d3d7-4490-bc73-d9172f64fded.png)
