### PR TITLE
Updating headings hierarchy to match new PMPro checkout page for a11y

### DIFF
--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -417,9 +417,9 @@ function pmpropp_render_payment_plans_checkout() {
 			?>
 			<div id="pmpropp_select_payment_plan" class="pmpro_checkout">
 				<hr />
-				<h3>
-					<span class="pmpro_checkout-h3-name"><?php _e( 'Select a Payment Plan', 'pmpro-payment-plans' ); ?></span>
-				</h3>
+				<h2>
+					<span class="pmpro_checkout-h2-name"><?php _e( 'Select a Payment Plan', 'pmpro-payment-plans' ); ?></span>
+				</h2>
 				<div id="pmpropp_payment_plans" class="pmpro_checkout-fields">
 					<!-- JavaScript populates plan options here -->
 				</div> <!-- end pmpro_checkout-fields -->


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.