### PR TITLE
[ENHANCEMENT] #62 Add support to pass payment plan as an URL param

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -20,7 +20,12 @@ jQuery(document).ready(function ($) {
 
 	// If there is a payment plan in the URL, select it and ignore the default
 	if ( payment_plan_query) {
-		appendPlanAndPriceByNumberId( payment_plan_query );
+		// Check if value is a number
+		if ( /^\d+$/.test( payment_plan_query ) ) {
+			appendPlanAndPriceByNumberId( payment_plan_query );
+		} else {
+			appendPlanAndPriceByPlanId( payment_plan_query );
+		}
 	// Apply the default plan if there is no plan in the URL
 	} else if ( default_plan ) {
 		appendPlanAndPrice( default_plan );

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -1,64 +1,95 @@
-jQuery(document).ready(function () {
+jQuery(document).ready(function ($) {
 
-	if (jQuery("#pmpropp_payment_plans").length > 0) {
-
-		jQuery.each(payment_plans.plans, function (key, val) {
-
-			jQuery("#pmpropp_payment_plans").append(val.html);
-
-			//Make sure the level cost text applies to the selected level
-			if (val.default == "yes") {
-
-				var data = {
-					action: 'pmpropp_request_price_change',
-					pmpro_level: payment_plans.parent_level,
-					plan: val.id
-				}
-
-				jQuery.post(payment_plans.ajaxurl, data, function (response) {
-					if (response !== '') {
-						jQuery("#pmpro_level_cost").html(response);
-					}
-				});
-
-			}
-
-		});
-
-		if (typeof localStorage !== 'undefined') {
-			var chosen_plan = localStorage.getItem('pmpropp_chosen_plan');
-			if (chosen_plan !== "") {
-				jQuery("#pmpropp_chosen_plan_choice_" + chosen_plan).click();
-			}
-		}
-
-		jQuery("body").on("click", ".pmpropp_chosen_plan", function () {
-
-			var value = jQuery(this).val();
-
-			jQuery.each(payment_plans.plans, function (key, val) {
-
-				if (val.id == value) {
-
-					var data = {
-						action: 'pmpropp_request_price_change',
-						pmpro_level: payment_plans.parent_level,
-						plan: value
-					}
-
-					jQuery.post(payment_plans.ajaxurl, data, function (response) {
-						if (response !== '') {
-							if (typeof localStorage !== 'undefined') {
-								localStorage.setItem('pmpropp_chosen_plan', value);
-							}
-							jQuery("#pmpro_level_cost").html(response);
-						}
-					});
-				}
-			});
-
-		});
-
+	// Bail if no payment plans are present
+	if ( payment_plans == undefined || payment_plans.plans.length === 0 ) {
+		return;
 	}
 
+	// Are there any payment plans in the URL?
+	const urlParams = new URLSearchParams( window.location.search );
+	const payment_plan_query = urlParams.get( 'pmpropp_chosen_plan' );
+
+	// Get the default payment plan
+	const default_plan = payment_plans.plans.find( plan => plan.default === "yes" && plan.id !== payment_plans.parent_level );
+
+	// Append the payment plans to the DOM
+	payment_plans.plans.forEach( element => {
+		$( "#pmpropp_payment_plans" ).append( element.html );
+	});
+
+
+	// If there is a payment plan in the URL, select it and ignore the default
+	if ( payment_plan_query) {
+		appendPlanAndPriceByNumberId( payment_plan_query );
+	// Apply the default plan if there is no plan in the URL
+	} else if ( default_plan ) {
+		appendPlanAndPrice( default_plan );
+	// No default plan, no plan in the URL, just select the plan from the local storage (last selected plan) if it
+	//exists, otherwise do nothing and parent level regular payment plan will be selected
+	} else {
+		const chosen_plan = localStorage.getItem( 'pmpropp_chosen_plan' );
+		if ( chosen_plan !== "" ) {
+			appendPlanAndPriceByPlanId( chosen_plan );
+		}
+	}
+
+	$( ".pmpropp_chosen_plan" ).on( "click", function( ) {
+		const planId = $(this).val();
+		appendPlanAndPriceByPlanId( planId );
+	});
+
 });
+
+/**
+ * Append the plan and price by the numberId (2)
+ *
+ * @param {number} numberId Just the int. The plan id is constructed as 'L-' + payment_plans.parent_level + '-P-' + numberId
+ * @since TBD
+ * @return {void}
+ */
+const appendPlanAndPriceByNumberId = ( numberId ) => {
+	const planId = 'L-' + payment_plans.parent_level + '-P-' + numberId;
+	appendPlanAndPriceByPlanId( planId );
+};
+
+/**
+ * Append the plan and price by the planId (L-2-P-0)
+ *
+ * @param {string} planId The plan id is constructed as 'L-' + payment_plans.parent_level + '-P-' + planId
+ * @since TBD
+ * @return {void}
+ */
+const appendPlanAndPriceByPlanId = ( planId ) => {
+	const plan = payment_plans.plans.find( plan => plan.id === planId );
+	appendPlanAndPrice( plan );
+};
+
+
+/**
+ * Append the plan and price by the plan object
+ *
+ * @param {Object} plan  The plan object
+ * @since TBD
+ * @return {void}
+ */
+const appendPlanAndPrice = ( plan ) => {
+	// Bail if no plan is present
+    if ( ! plan ) {
+		return;
+	}
+	//id="pmpropp_chosen_plan_choice_L-2-P-0"
+	jQuery( '#pmpropp_chosen_plan_choice_' + plan.id ).prop( 'checked', true );
+
+	const data = {
+		action: 'pmpropp_request_price_change',
+		pmpro_level: payment_plans.parent_level,
+		plan: plan.id,
+	};
+
+	jQuery.post( payment_plans.ajaxurl, data, ( response ) => {
+		if ( response !== '' ) {
+			localStorage.setItem( 'pmpropp_chosen_plan', plan.id );
+			jQuery( '#pmpro_level_cost' ).html( response );
+		}
+	});
+};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-payment-plans/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-payment-plans/pulls) for the same update/change?


Resolves #62

### How to test the changes in this Pull Request:

1. Create a checkout level with several ( at least 3 or 4 ) different payment plans.
2. Add to the checkout level link `pmpropp_chosen_plan=2 `as a param
3. Observe that the third plan is selected. Even if there's a default plan.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
