### PR TITLE
[BUGFIXING] #80 payment plan is saved empty at level creation if leve…

### DIFF
--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -161,21 +161,17 @@ add_action( 'pmpro_membership_level_after_trial_settings', 'pmpropp_membership_l
  *
  * @since 0.1
  */
-function pmpropp_membership_level_save() {
+function pmpropp_membership_level_save( $level_id ) {
 
-	if ( isset( $_REQUEST['saveid'] ) && ! empty( $_REQUEST['page'] ) && 'pmpro-membershiplevels' === $_REQUEST['page'] ) {
+	$payment_plans = pmpropp_pair_plan_fields( $_REQUEST );
 
-		$payment_plans = pmpropp_pair_plan_fields( $_REQUEST );
-		//Bail if we don't have any payment plans to save. Saving an empty array would  cause parse issues later.
-		if ( empty( $payment_plans ) ) {
-			return;
-		}
-
-		update_pmpro_membership_level_meta( $_REQUEST['saveid'], 'payment_plan', $payment_plans );
+	if ( empty( $payment_plans ) ) {
+		return;
 	}
 
+	update_pmpro_membership_level_meta( $level_id, 'payment_plan', $payment_plans );
 }
-add_action( 'admin_init', 'pmpropp_membership_level_save' );
+add_action( 'pmpro_save_membership_level', 'pmpropp_membership_level_save' );
 
 /**
  * Helper function to convert the settings into Membership Level Objects.

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -166,9 +166,12 @@ function pmpropp_membership_level_save() {
 	if ( isset( $_REQUEST['saveid'] ) && ! empty( $_REQUEST['page'] ) && 'pmpro-membershiplevels' === $_REQUEST['page'] ) {
 
 		$payment_plans = pmpropp_pair_plan_fields( $_REQUEST );
+		//Bail if we don't have any payment plans to save. Saving an empty array would  cause parse issues later.
+		if ( empty( $payment_plans ) ) {
+			return;
+		}
 
 		update_pmpro_membership_level_meta( $_REQUEST['saveid'], 'payment_plan', $payment_plans );
-
 	}
 
 }


### PR DESCRIPTION
…l isn't saved without error, after validation.

 * Bail if PP array is empty before saving it.

<img width="1527" alt="Screenshot 2025-01-07 at 3 54 23 PM" src="https://github.com/user-attachments/assets/030476fa-0e32-49e2-9e2a-0a904189938f" />



### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-payment-plans/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-payment-plans/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Bail if PP array is empty before saving it.

Resolves #80 

### How to test the changes in this Pull Request:

Follow steps described in the issue linked above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
