### PR TITLE
Add plugin row meta

### DIFF
--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -804,3 +804,17 @@ function pmpropp_add_payment_plans_to_site_health( $membership_level ) {
 }
 add_filter( 'pmpro_site_health_info_membership_level', 'pmpropp_add_payment_plans_to_site_health', 1, 1 );
 
+/**
+ * Function to add links to the plugin row meta
+ */
+function pmpropp_plugin_row_meta( $links, $file ) {
+	if ( strpos( $file, 'pmpro-payment-plans.php' ) !== false ) {
+		$new_links = array(
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-payment-plans/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-payment-plans' ) ) . '">' . __( 'Docs', 'pmpro-payment-plans' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-payment-plans' ) ) . '">' . __( 'Support', 'pmpro-payment-plans' ) . '</a>',
+		);
+		$links     = array_merge( $links, $new_links );
+	}
+	return $links;
+}
+add_filter( 'plugin_row_meta', 'pmpropp_plugin_row_meta', 10, 2 );


### PR DESCRIPTION
Add function `pmpropp_plugin_row_meta` to add doc and support links to plugin row meta.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-payment-plans/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-payment-plans/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds functionality to show plugin documentation and support links.

### How to test the changes in this Pull Request:

1. Navigate to **Plugins > Installed Plugins**
2. Locate the "Paid Memberships Pro - Payment Plans" plugin
3. Verify that the "Docs" and "Support" show and links correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Add docs and support links to plugin row meta.
