### PR TITLE
BUG FIX: Target correct selector when updating level cost on plan change

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -94,7 +94,7 @@ const appendPlanAndPrice = ( plan ) => {
 	jQuery.post( payment_plans.ajaxurl, data, ( response ) => {
 		if ( response !== '' ) {
 			localStorage.setItem( 'pmpropp_chosen_plan', plan.id );
-			jQuery( '#pmpro_level_cost' ).html( response );
+			jQuery( '.pmpro_level_cost_text' ).html( response );
 		}
 	});
 };

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -94,7 +94,7 @@ const appendPlanAndPrice = ( plan ) => {
 	jQuery.post( payment_plans.ajaxurl, data, ( response ) => {
 		if ( response !== '' ) {
 			localStorage.setItem( 'pmpropp_chosen_plan', plan.id );
-			jQuery( '.pmpro_level_cost_text' ).html( response );
+			jQuery( '#pmpro_level_cost' ).html( response );
 		}
 	});
 };

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -592,8 +592,25 @@ function pmpropp_request_price_change() {
 		pmprorate_pmpro_checkout_level( $plan );
 	}
 
-	//Return the changed level cost text and expiration
-	echo '<p>' . trim( pmpro_no_quotes( pmpro_getLevelCost( $plan, array( '"', "'", "\n", "\r" ) ) . ' '. pmpro_getLevelExpiration( $plan ) ) ) . '</p>';
+	// Return the changed level cost text and expiration, structured to match core's checkout markup.
+	$level_cost_text       = pmpro_no_quotes( pmpro_getLevelCost( $plan, array( '"', "'", "\n", "\r" ) ) );
+	$level_expiration_text = pmpro_no_quotes( pmpro_getLevelExpiration( $plan ) );
+
+	if ( ! empty( $level_cost_text ) ) {
+		?>
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_cost_text' ) ); ?>">
+			<?php echo wp_kses_post( wpautop( $level_cost_text ) ); ?>
+		</div>
+		<?php
+	}
+
+	if ( ! empty( $level_expiration_text ) ) {
+		?>
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_expiration_text' ) ); ?>">
+			<?php echo wp_kses_post( wpautop( $level_expiration_text ) ); ?>
+		</div>
+		<?php
+	}
 
 	wp_die();
 

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -593,7 +593,7 @@ function pmpropp_request_price_change() {
 	}
 
 	//Return the changed level cost text and expiration
-	echo trim( pmpro_no_quotes( pmpro_getLevelCost( $plan, array( '"', "'", "\n", "\r" ) ) . ' '. pmpro_getLevelExpiration( $plan ) ) );
+	echo '<p>' . trim( pmpro_no_quotes( pmpro_getLevelCost( $plan, array( '"', "'", "\n", "\r" ) ) . ' '. pmpro_getLevelExpiration( $plan ) ) ) . '</p>';
 
 	wp_die();
 


### PR DESCRIPTION
## Summary
Fixes JavaScript targeting the wrong div when updating the level cost on plan change, causing layout jump.

## The Bug
- The JS was targeting `#pmpro_level_cost` and replacing its inner HTML
- This caused the entire cost div to jump when the price updated
- Core PMPro wraps the text in `.pmpro_level_cost_text` inside the `#pmpro_level_cost` div

## The Fix
1. Updated `js/frontend.js` to target `.pmpro_level_cost_text` instead of `#pmpro_level_cost`
2. Wrapped the AJAX response in a `<p>` tag for consistency with core PMPro's level cost display

## Testing
1. Create a membership level with payment plans
2. Go to the checkout page
3. Switch between payment plans
4. Verify the price updates smoothly without layout jump
5. Verify the price text is properly formatted in a `<p>` tag

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)