### PR TITLE
Updates to store plan in subscription meta; showing plan on orders and subscriptions tables

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -47,7 +47,7 @@ function pmpropp_orderslist_custom_column( $column_name, $order_id ) {
 	if ( ! empty( $plan->name ) ) {
 		echo esc_html( $plan->name );
 	} else {
-		echo esc_html__( '&#8212;', 'paid-memberships-pro' );
+		echo '&#8212;';
 	}
 }
 add_action( 'pmpro_manage_orderlist_custom_column', 'pmpropp_orderslist_custom_column', 10, 2 );
@@ -82,7 +82,7 @@ function pmpropp_subscriptionslist_custom_column( $column_name, $item ) {
 	if ( ! empty( $plan->name ) ) {
 		echo esc_html( $plan->name );
 	} else {
-		echo esc_html__( '&#8212;', 'paid-memberships-pro' );
+		echo '&#8212;';
 	}
 }
 add_action( 'pmpro_manage_subscriptionlist_custom_column', 'pmpropp_subscriptionslist_custom_column', 10, 2 );
@@ -113,7 +113,7 @@ function pmpropp_edit_member_subscriptions_extra_cols_body( $subscription ) {
 	if ( ! empty( $plan->name ) ) {
 		echo '<td>' . esc_html( $plan->name ) . '</td>';
 	} else {
-		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+		echo '<td>&#8212;</td>';
 	}
 }
 add_action( 'pmpro_edit_member_subscriptions_extra_cols_body', 'pmpropp_edit_member_subscriptions_extra_cols_body' );
@@ -206,7 +206,7 @@ function pmpropp_member_orders_extra_cols_body( $order ) {
 	if ( ! empty( $plan->name ) ) {
 		echo '<td>' . esc_html( $plan->name ) . '</td>';
 	} else {
-		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+		echo '<td>&#8212;</td>';
 	}
 }
 add_action( 'pmpromh_orders_extra_cols_body', 'pmpropp_member_orders_extra_cols_body' );
@@ -241,6 +241,10 @@ function pmpropp_member_history_extra_cols_body( $user, $level ) {
 	$plan = null;
 
 	if ( ! empty( $user->ID ) && ! empty( $level->id ) && class_exists( 'PMPro_Subscription' ) ) {
+		// Known limitation: if a user canceled and resubscribed at the same level,
+		// every history row for that level will show the first subscription's plan.
+		// The history rows aren't tied to a specific subscription so we can't pick
+		// the matching one here.
 		$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user->ID, $level->id );
 		if ( ! empty( $subscriptions ) ) {
 			$plan = get_pmpro_subscription_meta( $subscriptions[0]->get_id(), 'payment_plan', true );
@@ -250,7 +254,7 @@ function pmpropp_member_history_extra_cols_body( $user, $level ) {
 	if ( ! empty( $plan->name ) ) {
 		echo '<td>' . esc_html( $plan->name ) . '</td>';
 	} else {
-		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+		echo '<td>&#8212;</td>';
 	}
 }
 add_action( 'pmpromh_member_history_extra_cols_body', 'pmpropp_member_history_extra_cols_body', 10, 2 );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Admin display: Payment Plan columns and sections on PMPro admin screens.
+ *
+ * @since TBD
+ */
+
+/**
+ * Add the Payment Plan column to the Orders list table.
+ *
+ * @since TBD
+ */
+function pmpropp_orderslist_columns( $columns ) {
+	$columns['pmpropp_payment_plan'] = esc_html__( 'Payment Plan', 'pmpro-payment-plans' );
+	return $columns;
+}
+add_filter( 'pmpro_manage_orderslist_columns', 'pmpropp_orderslist_columns' );
+
+/**
+ * Render the Payment Plan column on the Orders list table.
+ *
+ * Reads from subscription meta first so recurring orders display the plan;
+ * falls back to order meta for one-time payments and legacy data.
+ *
+ * @since TBD
+ */
+function pmpropp_orderslist_custom_column( $column_name, $order_id ) {
+
+	if ( 'pmpropp_payment_plan' !== $column_name ) {
+		return;
+	}
+
+	$plan = null;
+
+	$morder = new MemberOrder( $order_id );
+	if ( ! empty( $morder->id ) ) {
+		$subscription = is_callable( array( $morder, 'get_subscription' ) ) ? $morder->get_subscription() : null;
+		if ( ! empty( $subscription ) ) {
+			$plan = get_pmpro_subscription_meta( $subscription->get_id(), 'payment_plan', true );
+		}
+	}
+
+	if ( empty( $plan ) ) {
+		$plan = get_pmpro_membership_order_meta( $order_id, 'payment_plan', true );
+	}
+
+	if ( ! empty( $plan->name ) ) {
+		echo esc_html( $plan->name );
+	} else {
+		echo esc_html__( '&#8212;', 'paid-memberships-pro' );
+	}
+}
+add_action( 'pmpro_manage_orderlist_custom_column', 'pmpropp_orderslist_custom_column', 10, 2 );
+
+/**
+ * Add the Payment Plan column to the Subscriptions list table.
+ *
+ * @since TBD
+ */
+function pmpropp_subscriptionslist_columns( $columns ) {
+	$columns['pmpropp_payment_plan'] = esc_html__( 'Payment Plan', 'pmpro-payment-plans' );
+	return $columns;
+}
+add_filter( 'pmpro_manage_subscriptionslist_columns', 'pmpropp_subscriptionslist_columns' );
+
+/**
+ * Render the Payment Plan column on the Subscriptions list table.
+ *
+ * @since TBD
+ *
+ * @param string             $column_name The column being rendered.
+ * @param PMPro_Subscription $item        The subscription for this row.
+ */
+function pmpropp_subscriptionslist_custom_column( $column_name, $item ) {
+
+	if ( 'pmpropp_payment_plan' !== $column_name ) {
+		return;
+	}
+
+	$plan = empty( $item ) ? null : get_pmpro_subscription_meta( $item->get_id(), 'payment_plan', true );
+
+	if ( ! empty( $plan->name ) ) {
+		echo esc_html( $plan->name );
+	} else {
+		echo esc_html__( '&#8212;', 'paid-memberships-pro' );
+	}
+}
+add_action( 'pmpro_manage_subscriptionlist_custom_column', 'pmpropp_subscriptionslist_custom_column', 10, 2 );
+
+/**
+ * Add the Payment Plan column header to the Edit Member → Subscriptions panel.
+ *
+ * Hook is provided by a pending PMPro core PR.
+ *
+ * @since TBD
+ */
+function pmpropp_edit_member_subscriptions_extra_cols_header() {
+	echo '<th>' . esc_html__( 'Payment Plan', 'pmpro-payment-plans' ) . '</th>';
+}
+add_action( 'pmpro_edit_member_subscriptions_extra_cols_header', 'pmpropp_edit_member_subscriptions_extra_cols_header' );
+
+/**
+ * Render the Payment Plan column on the Edit Member → Subscriptions panel.
+ *
+ * @since TBD
+ *
+ * @param PMPro_Subscription $subscription The subscription for this row.
+ */
+function pmpropp_edit_member_subscriptions_extra_cols_body( $subscription ) {
+
+	$plan = empty( $subscription ) ? null : get_pmpro_subscription_meta( $subscription->get_id(), 'payment_plan', true );
+
+	if ( ! empty( $plan->name ) ) {
+		echo '<td>' . esc_html( $plan->name ) . '</td>';
+	} else {
+		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+	}
+}
+add_action( 'pmpro_edit_member_subscriptions_extra_cols_body', 'pmpropp_edit_member_subscriptions_extra_cols_body' );
+
+/**
+ * Render a Payment Plan section on the single subscription view page.
+ *
+ * Hook is provided by a pending PMPro core PR. Bails (renders nothing) when
+ * the subscription has no plan attached.
+ *
+ * @since TBD
+ *
+ * @param PMPro_Subscription $subscription The subscription being viewed.
+ */
+function pmpropp_after_subscription_view_main( $subscription ) {
+
+	if ( empty( $subscription ) ) {
+		return;
+	}
+
+	$plan = get_pmpro_subscription_meta( $subscription->get_id(), 'payment_plan', true );
+	if ( empty( $plan->name ) ) {
+		return;
+	}
+	?>
+	<div id="pmpropp_subscription-view-payment-plan" class="pmpro_section" data-visibility="shown" data-activated="true">
+		<div class="pmpro_section_toggle">
+			<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+				<span class="dashicons dashicons-arrow-up-alt2"></span>
+				<?php esc_html_e( 'Payment Plan', 'pmpro-payment-plans' ); ?>
+			</button>
+		</div>
+		<div class="pmpro_section_inside">
+			<ul class="pmpro_list pmpro_list-plain pmpro_list-with-labels pmpro_cols-2">
+				<li class="pmpro_list_item">
+					<span class="pmpro_list_item_label"><?php esc_html_e( 'Plan Name', 'pmpro-payment-plans' ); ?></span>
+					<?php echo esc_html( $plan->name ); ?>
+				</li>
+				<?php if ( ! empty( $plan->description ) ) { ?>
+					<li class="pmpro_list_item">
+						<span class="pmpro_list_item_label"><?php esc_html_e( 'Description', 'pmpro-payment-plans' ); ?></span>
+						<?php echo wp_kses_post( $plan->description ); ?>
+					</li>
+				<?php } ?>
+			</ul>
+		</div>
+	</div>
+	<?php
+}
+add_action( 'pmpro_after_subscription_view_main', 'pmpropp_after_subscription_view_main' );
+
+/**
+ * Add the Payment Plan column header to the per-member orders tables.
+ *
+ * Covers the Edit Member → Orders panel and the legacy user-edit profile
+ * orders table.
+ *
+ * @since TBD
+ */
+function pmpropp_member_orders_extra_cols_header() {
+	echo '<th>' . esc_html__( 'Payment Plan', 'pmpro-payment-plans' ) . '</th>';
+}
+add_action( 'pmpromh_orders_extra_cols_header', 'pmpropp_member_orders_extra_cols_header' );
+
+/**
+ * Render the Payment Plan column on the per-member orders tables.
+ *
+ * Reads from subscription meta first (recurring orders), falls back to order
+ * meta for one-time payments and legacy data.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order for this row.
+ */
+function pmpropp_member_orders_extra_cols_body( $order ) {
+
+	$plan = null;
+
+	if ( ! empty( $order ) ) {
+		$subscription = is_callable( array( $order, 'get_subscription' ) ) ? $order->get_subscription() : null;
+		if ( ! empty( $subscription ) ) {
+			$plan = get_pmpro_subscription_meta( $subscription->get_id(), 'payment_plan', true );
+		}
+
+		if ( empty( $plan ) && ! empty( $order->id ) ) {
+			$plan = get_pmpro_membership_order_meta( $order->id, 'payment_plan', true );
+		}
+	}
+
+	if ( ! empty( $plan->name ) ) {
+		echo '<td>' . esc_html( $plan->name ) . '</td>';
+	} else {
+		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+	}
+}
+add_action( 'pmpromh_orders_extra_cols_body', 'pmpropp_member_orders_extra_cols_body' );
+
+/**
+ * Add the Payment Plan column header to the membership history tables.
+ *
+ * Covers the Edit Member → Memberships panel history table and the legacy
+ * user-edit profile membership history.
+ *
+ * @since TBD
+ */
+function pmpropp_member_history_extra_cols_header() {
+	echo '<th>' . esc_html__( 'Payment Plan', 'pmpro-payment-plans' ) . '</th>';
+}
+add_action( 'pmpromh_member_history_extra_cols_header', 'pmpropp_member_history_extra_cols_header' );
+
+/**
+ * Render the Payment Plan column on the membership history tables.
+ *
+ * Looks up subscriptions for the user/level pair and reads the plan from
+ * subscription meta. Bounded to a single member's history, so the per-row
+ * lookup cost is fine here.
+ *
+ * @since TBD
+ *
+ * @param WP_User $user  The member.
+ * @param object  $level The level row from the user's history.
+ */
+function pmpropp_member_history_extra_cols_body( $user, $level ) {
+
+	$plan = null;
+
+	if ( ! empty( $user->ID ) && ! empty( $level->id ) && class_exists( 'PMPro_Subscription' ) ) {
+		$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user->ID, $level->id );
+		if ( ! empty( $subscriptions ) ) {
+			$plan = get_pmpro_subscription_meta( $subscriptions[0]->get_id(), 'payment_plan', true );
+		}
+	}
+
+	if ( ! empty( $plan->name ) ) {
+		echo '<td>' . esc_html( $plan->name ) . '</td>';
+	} else {
+		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+	}
+}
+add_action( 'pmpromh_member_history_extra_cols_body', 'pmpropp_member_history_extra_cols_body', 10, 2 );

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -575,16 +575,16 @@ function pmpropp_migrate_payment_plan_subscription_meta( $value, $subscription_i
 		'orderby' => '`timestamp` ASC, `id` ASC',
 		'limit'   => 1,
 	) );
-	if ( empty( $orders ) ) {
-		return $value;
-	}
 
-	$plan = get_pmpro_membership_order_meta( $orders[0]->id, 'payment_plan', true );
+	$plan = empty( $orders ) ? '' : get_pmpro_membership_order_meta( $orders[0]->id, 'payment_plan', true );
+
+	// Persist a row either way so this filter doesn't refire on every read for
+	// subscriptions that genuinely have no plan (pre-plugin or planless checkouts).
+	update_pmpro_subscription_meta( $subscription_id, 'payment_plan', empty( $plan ) ? '' : $plan );
+
 	if ( empty( $plan ) ) {
 		return $value;
 	}
-
-	update_pmpro_subscription_meta( $subscription_id, 'payment_plan', $plan );
 
 	return $single ? $plan : array( $plan );
 }

--- a/pmpro-payment-plans.php
+++ b/pmpro-payment-plans.php
@@ -16,7 +16,18 @@ define( 'PMPROPP_VERSION', '0.5' );
  * Includes the cleanup script on uninstall.
  */
 include plugin_dir_path( __FILE__ ) . 'includes/uninstall.php';
-function pmpropp_activate(){
+
+/**
+ * Admin display: Payment Plan columns and sections on PMPro admin screens.
+ */
+if ( is_admin() ) {
+	include plugin_dir_path( __FILE__ ) . 'includes/admin.php';
+}
+
+/**
+ * Activation hook to register the uninstall hook.
+ */
+function pmpropp_activate() {
     register_uninstall_hook( __FILE__, 'pmpropp_uninstall' );
 }
 register_activation_hook( __FILE__, 'pmpropp_activate' );
@@ -524,6 +535,12 @@ function pmpropp_after_checkout( $user_id, $morder ) {
 
 		if ( ! empty( $plan ) ) {
 			update_pmpro_membership_order_meta( intval( $morder->id ), 'payment_plan', $plan );
+
+			// Also store on the subscription so reports can group by plan across recurring orders.
+			$subscription = is_callable( array( $morder, 'get_subscription' ) ) ? $morder->get_subscription() : null;
+			if ( ! empty( $subscription ) ) {
+				update_pmpro_subscription_meta( $subscription->get_id(), 'payment_plan', $plan );
+			}
 		}
 
 	}
@@ -531,35 +548,47 @@ function pmpropp_after_checkout( $user_id, $morder ) {
 }
 add_action( 'pmpro_after_checkout', 'pmpropp_after_checkout', 10, 2 );
 
-/**
- * Add payment plan column header to orders page.
- *
- * @since 0.1
- */
-function pmpropp_payment_plan_header() {
-
-	echo '<th>' . esc_html__( 'Payment Plan', 'pmpro-payment-plans' ) . '</th>';
-
-}
-add_action( 'pmpro_orders_extra_cols_header', 'pmpropp_payment_plan_header', 10 );
+// Admin display callbacks (column rendering, single-sub view section) live in includes/admin.php.
 
 /**
- * Add payment plan column to the order page.
+ * Slow-patch: backfill the `payment_plan` subscription meta from the
+ * subscription's original order on first read.
  *
- * @since 0.1
+ * Older checkouts only stored the plan on the first order. WP fires
+ * `default_pmpro_subscription_metadata` only when the meta row is missing, so
+ * each subscription is patched at most once, the next time something reads it.
+ *
+ * @since TBD
  */
-function pmpropp_payment_plan_body( $morder ) {
+function pmpropp_migrate_payment_plan_subscription_meta( $value, $subscription_id, $meta_key, $single ) {
 
-	$plan = get_pmpro_membership_order_meta( $morder->id, 'payment_plan', true );
-
-	if ( ! empty( $plan->name ) ) {
-		echo '<td>' . esc_html( $plan->name ) . '</td>';
-	} else {
-		echo '<td>' . esc_html__( '&#8212;', 'paid-memberships-pro' ) . '</td>';
+	if ( 'payment_plan' !== $meta_key ) {
+		return $value;
 	}
 
+	$subscription = new PMPro_Subscription( $subscription_id );
+	if ( empty( $subscription->get_id() ) ) {
+		return $value;
+	}
+
+	$orders = $subscription->get_orders( array(
+		'orderby' => '`timestamp` ASC, `id` ASC',
+		'limit'   => 1,
+	) );
+	if ( empty( $orders ) ) {
+		return $value;
+	}
+
+	$plan = get_pmpro_membership_order_meta( $orders[0]->id, 'payment_plan', true );
+	if ( empty( $plan ) ) {
+		return $value;
+	}
+
+	update_pmpro_subscription_meta( $subscription_id, 'payment_plan', $plan );
+
+	return $single ? $plan : array( $plan );
 }
-add_action( 'pmpro_orders_extra_cols_body', 'pmpropp_payment_plan_body', 10, 1 );
+add_filter( 'default_pmpro_subscription_metadata', 'pmpropp_migrate_payment_plan_subscription_meta', 10, 4 );
 
 /**
  * Ajax request to handle price change on checkout.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-payment-plans/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-payment-plans/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Storing the plan data in subscription meta
- Showing the plan on Orders and Subscriptions list tables
- Showing the plan on the Subscriptions view screen (requires a core PMPro PR to merge)
- Showing the plan on the Edit Member Orders and Subscriptions (requires a core PMPro PR to merge) views, as well as the Member History table
- Self healing script for when the subscription meta is requested to copy over from "subscription's first order" if not found.
